### PR TITLE
Create sentiment API with endpoint to query model service

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests~=2.32.3
+flask

--- a/src/sentiment_api.py
+++ b/src/sentiment_api.py
@@ -49,6 +49,19 @@ def analyze_sentiment():
 
     return jsonify({'sentiment': sentiment_prediction}), 200
 
+
+@sentiment_api.route('/api/v1/correct-prediction', methods=['POST'])
+def correct_prediction():
+    """
+        Correct the predicted sentiment. As of now, this is not stored anywhere.
+        """
+    data = request.get_json()
+    if not data or not all(field in data for field in ['text', 'original_prediction', 'corrected_prediction']):
+        return jsonify({'error': 'Missing required fields in JSON payload.'}), 400
+
+    return jsonify({'message': 'Your correction has been processed.'}), 200
+
+
 @sentiment_api.route('/api/v1/version', methods=['GET'])
 def get_version():
     """

--- a/src/sentiment_api.py
+++ b/src/sentiment_api.py
@@ -5,6 +5,9 @@ from requests.exceptions import RequestException, HTTPError
 
 MODEL_SERVICE_URL = os.getenv('SENTIMENT_MODEL_ENDPOINT')
 
+APP_SERVICE_VERSION = os.getenv('APP_SERVICE_VERSION')
+MODEL_SERVICE_VERSION = os.getenv('MODEL_SERVICE_VERSION')
+
 sentiment_api = Flask(__name__)
 
 @sentiment_api.route('/api/sentiment', methods=['POST'])
@@ -35,3 +38,12 @@ def analyze_sentiment(input_text: str):
     result = response.json()
 
     return jsonify({'sentiment': result}), 200
+
+@sentiment_api.route('/api/version', methods=['GET'])
+def get_version():
+    return jsonify(
+        {
+            'app_service_version': APP_SERVICE_VERSION,
+            'model_service_version': MODEL_SERVICE_VERSION
+         }
+    ), 200

--- a/src/sentiment_api.py
+++ b/src/sentiment_api.py
@@ -1,0 +1,37 @@
+import os
+import requests
+from flask import jsonify, Flask
+from requests.exceptions import RequestException, HTTPError
+
+MODEL_SERVICE_URL = os.getenv('SENTIMENT_MODEL_ENDPOINT')
+
+sentiment_api = Flask(__name__)
+
+@sentiment_api.route('/api/sentiment', methods=['POST'])
+def analyze_sentiment(input_text: str):
+    """
+        Analyze the sentiment of the provided input text by sending it to the model service.
+
+        Args:
+            input_text (str): The text for which sentiment analysis is to be performed.
+
+        Returns:
+            Response: A Flask JSON response with the sentiment result or an error message.
+        """
+    if len(input_text) == 0:
+        return jsonify({'error': 'Input text cannot be empty.'}), 400
+
+    try:
+        response = requests.post(
+            url=MODEL_SERVICE_URL,
+            json={'text': input_text}
+        )
+        response.raise_for_status()
+    except HTTPError as e:
+        return jsonify({'error': f"Error in model service: {str(e)}"}), 500
+    except RequestException as e:
+        return jsonify({'error': f"Failed to connect to model service: {str(e)}"}), 503
+
+    result = response.json()
+
+    return jsonify({'sentiment': result}), 200

--- a/src/sentiment_api.py
+++ b/src/sentiment_api.py
@@ -1,28 +1,39 @@
 import os
 import requests
-from flask import jsonify, Flask
+from flask import jsonify, Flask, request
 from requests.exceptions import RequestException, HTTPError
 
-MODEL_SERVICE_URL = os.getenv('SENTIMENT_MODEL_ENDPOINT')
+MODEL_SERVICE_URL = os.getenv('MODEL_SERVICE_URL')
+APP_SERVICE_VERSION = os.getenv('APP_SERVICE_VERSION', 'unknown')
 
-APP_SERVICE_VERSION = os.getenv('APP_SERVICE_VERSION')
-MODEL_SERVICE_VERSION = os.getenv('MODEL_SERVICE_VERSION')
+if not MODEL_SERVICE_URL:
+    raise EnvironmentError("MODEL_SERVICE_URL environment variable is not set.")
 
 sentiment_api = Flask(__name__)
 
-@sentiment_api.route('/api/sentiment', methods=['POST'])
-def analyze_sentiment(input_text: str):
+@sentiment_api.route('/api/v1/sentiment', methods=['POST'])
+def analyze_sentiment():
     """
-        Analyze the sentiment of the provided input text by sending it to the model service.
+    Analyze the sentiment of the provided input text by sending it to the model service.
 
-        Args:
-            input_text (str): The text for which sentiment analysis is to be performed.
+    Expects JSON request body: {"text": "<input_text>"}
 
-        Returns:
-            Response: A Flask JSON response with the sentiment result or an error message.
-        """
-    if len(input_text) == 0:
-        return jsonify({'error': 'Input text cannot be empty.'}), 400
+    Returns:
+        Response: A JSON response with the sentiment result or an error message.
+    """
+    try:
+        data = request.get_json()
+        if not data or 'text' not in data:
+            return jsonify({'error': 'Missing "text" field in JSON payload.'}), 400
+
+        input_text: str = data['text']
+        if not isinstance(input_text, str):
+            return jsonify({'error': 'Input text must be a string.'}), 400
+        if not input_text.strip():
+            return jsonify({'error': 'Input text cannot be empty.'}), 400
+
+    except ValueError:
+        return jsonify({'error': 'Invalid JSON payload.'}), 400
 
     try:
         response = requests.post(
@@ -30,20 +41,34 @@ def analyze_sentiment(input_text: str):
             json={'text': input_text}
         )
         response.raise_for_status()
+        sentiment_prediction = response.json().get('sentiment')
     except HTTPError as e:
         return jsonify({'error': f"Error in model service: {str(e)}"}), 500
     except RequestException as e:
         return jsonify({'error': f"Failed to connect to model service: {str(e)}"}), 503
 
-    result = response.json()
+    return jsonify({'sentiment': sentiment_prediction}), 200
 
-    return jsonify({'sentiment': result}), 200
-
-@sentiment_api.route('/api/version', methods=['GET'])
+@sentiment_api.route('/api/v1/version', methods=['GET'])
 def get_version():
+    """
+    Retrieve the version of the app and model service.
+
+    Returns:
+        Response: A JSON response with version information.
+    """
+    try:
+        response = requests.get(f'{MODEL_SERVICE_URL}/api/version')
+        response.raise_for_status()
+        model_service_version = response.json().get('model_service_version', 'unknown')
+    except HTTPError as e:
+        return jsonify({'error': f"Error in model service: {str(e)}"}), 500
+    except RequestException as e:
+        return jsonify({'error': f"Failed to connect to model service: {str(e)}"}), 503
+
     return jsonify(
         {
             'app_service_version': APP_SERVICE_VERSION,
-            'model_service_version': MODEL_SERVICE_VERSION
+            'model_service_version': model_service_version
          }
     ), 200


### PR DESCRIPTION
- Create sentiment API with endpoint to query model service
- The URL of the model-service is configurable as an environment variable.