### PR TITLE
Add metrics to app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ requests
 flasgger
 flask
 python-dotenv
+prometheus_client
+psutil
 lib_version @ https://github.com/remla25-team17/lib-version/releases/download/0.1.6/lib_version-0.0.0-py3-none-any.whl
-
-

--- a/src/specs/get_metrics.yml
+++ b/src/specs/get_metrics.yml
@@ -1,0 +1,16 @@
+tags:
+  - Metrics
+description: |
+  This endpoint collects the current system metrics, and then returns all metrics in a
+  format compatible with Prometheus scraping.
+produces:
+  - text/plain
+responses:
+  200:
+    description: A plaintext response with Prometheus metrics and HTTP 200 status.
+    content:
+      text/plain:
+        schema:
+          type: string
+  500:
+    description: Internal server error if metrics could not be collected.


### PR DESCRIPTION
## Overview
Introduced metrics for request number (Counter), CPU and RAM usage (Gauge) as well as request latency (Histogram). Labels are used to group by status code and path. These metrics are being exposed to the ServiceMonitor through a metrics endpoint (`/api/v1/metrics`).

## 📋 Pull Request Checklist

Please review and check all the following:

- [x] I have added an overview of the changes
- [x] I have tested my changes locally
- [x] I have updated documentation (if applicable)

---

## 🚀 Versioning (Required for GitVersion)

- [ ] The **PR includes a commit** with one of the following GitVersion tags in the **message**:
  - `#major` – breaking change
  - `#minor` – new feature
  - `#patch` – bug fix or minor update  
  - _If omitted, the version will default to_ `patch`
