### PR TITLE
Restore original UI

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,6 @@
             padding: 8px;
             margin-bottom: 16px;
             box-sizing: border-box;
-            height: 120px;
         }
         .button {
             background-color: #2e8b57;
@@ -105,8 +104,7 @@
                 <h2 class="title">How was your experience?</h2>
                 <p>We appreciate your feedback, and we are committed to understanding your experience. To help us improve, we aim to classify your review as positive or negative. Please share your thoughts below.</p>
                 <div>
-                    <textarea id="userInput" name="userInput" placeholder="Type your review here (provide more details for better analysis) ..." class="box"></textarea>
-                    <div id="characterCounter" style="text-align: right; font-size: 12px; color: #666; margin-bottom: 8px;">0</div>
+                <textarea id="userInput" name="userInput" placeholder="Type your review here..." class="box"> </textarea>
                 </div>
                 <button type="submit" onclick="sendInput()" class="button">Analyze Review</button>
                 <div id="responseContainer">
@@ -164,26 +162,6 @@
             }
 
             document.addEventListener("DOMContentLoaded", function() {
-                const textarea = document.getElementById('userInput');
-                const charCount = document.getElementById('characterCounter');
-
-                updateCharCount();
-
-                textarea.addEventListener('input', updateCharCount);
-
-                function updateCharCount() {
-                    const count = textarea.value.length;
-                    charCount.textContent = count;
-
-                    if (count < 20) {
-                        charCount.style.color = 'red';
-                    } else if (count <= 40) {
-                        charCount.style.color = 'orange';
-                    } else {
-                        charCount.style.color = 'green';
-                    }
-                }
-
                 fetch("/api/v1/version")
                 .then(response => response.json())
                 .then(data => {


### PR DESCRIPTION
## Overview

The previous PR introduced both the new UI for the continuous experiment and a new metric, `input_text_length`, used to evaluate it. However, this created a gap: we now lack a version of `app-service` that retains the original UI while also tracking the new metric, which we need for the continuous experiment.

This PR addresses that gap by creating a new version of `app-service` that preserves the original UI but includes support for the `input_text_length` metric. This allows us to run a proper A/B test with consistent metric tracking across both variants.

Attempts to use pre-release versions in Helm for this purpose were unsuccessful, so this PR provides a stable version explicitly for the original UI + new metric combination.

## 📋 Pull Request Checklist

Please review and check all the following:

- [x] I have added an overview of the changes
- [x] I have tested my changes locally
- [ ] I have updated documentation (if applicable)

---

## 🚀 Versioning (Required for GitVersion)

- [ ] The **PR includes a commit** with one of the following GitVersion tags in the **message**:
  - `#major` – breaking change
  - `#minor` – new feature
  - `#patch` – bug fix or minor update  
  - _If omitted, the version will default to_ `patch`
